### PR TITLE
Fix BigInt error on activity details page

### DIFF
--- a/ui/src/components/activity/ActivityDetails/Version.js
+++ b/ui/src/components/activity/ActivityDetails/Version.js
@@ -6,8 +6,9 @@ import moment from 'moment';
 import { STATUS_COMPLETED } from '../../../constants';
 import styles from './Version.module.css';
 
+/* global BigInt */
 const ldapToJS = n => {
-  return new Date(n / 1e4 - 1.16444736e13);
+  return new Date(Number(BigInt(n) / BigInt(1e4 - 1.16444736e13)));
 };
 
 export class Version extends Component {


### PR DESCRIPTION
Activity details page isn't loading correctly because of the huge timestamps. This should resolve it though we really should get rid of these timestamps.